### PR TITLE
Enable usage on single-core devices

### DIFF
--- a/src/signalDecoder.h
+++ b/src/signalDecoder.h
@@ -32,7 +32,7 @@
 
 // Decoder task settings
 #define rtl_433_Decoder_Priority 2
-#define rtl_433_Decoder_Core     1
+#define rtl_433_Decoder_Core     tskNO_AFFINITY
 
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
Without this, it immediately crashes on a single-core ESP32:

> assert failed: xTaskCreatePinnedToCore freertos_tasks_c_additions.h:163